### PR TITLE
scrumpoints as floats: allow the scrumpoint 0.5 or 0,5

### DIFF
--- a/js/trello-pro.js
+++ b/js/trello-pro.js
@@ -422,7 +422,10 @@ TrelloPro.refreshData = function() {
       // count points
       list.totalPoints = 0;
       $this.find('.tpro-point').each(function(){
-        list.totalPoints += parseInt(jQuery.trim(jQuery(this).text()).match(/\d+/)[0]);
+          let matches = jQuery.trim(jQuery(this).text()).match(/[.,\d]+/g);
+          if(matches && matches[0]){
+              list.totalPoints += parseFloat(matches[0].replace(",", "."));
+          }
       });
 
       // count checklist tasks


### PR DESCRIPTION
In my team, we use the following scrum points sequence: 0.5, 1, 2, 3, 5, 8, ...
Currently the 0.5 is not allowed. It will not be counted in the total number of scrumpoints. That is why I've created this fix

The new code does this:
=> parse with an updated regex
=> replace the decimal comma by decimal point  (to allow both 0.5 as 0,5)
=> parse as float and add to total

Can you please test it and merge it. Thanks

I hope you like what I did

btw great plugin!!