### PR TITLE
adding intendation feature

### DIFF
--- a/css/intend-cards.css
+++ b/css/intend-cards.css
@@ -1,0 +1,11 @@
+.list-card.tpro-intend-level1 {
+    margin-left: 1em;
+}
+
+.list-card.tpro-intend-level2 {
+    margin-left: 2em;
+}
+
+.list-card.tpro-intend-level3 {
+    margin-left: 3em;
+}

--- a/js/config.js
+++ b/js/config.js
@@ -45,6 +45,8 @@ TrelloPro.config = {
 		'show-list-stats-progressbar': false,
 		'hide-add-list': false,
 		'custom-css': false,
-		'custom-css-input': ''
+		'custom-css-input': '',
+
+		'intend-cards': false
 	}
 }

--- a/js/trello-pro.js
+++ b/js/trello-pro.js
@@ -127,6 +127,24 @@ TrelloPro.cardNameChange = function ($title,refreshData) {
       }
     }
 
+    // intendation       
+    // intends the card according to the amount of dashes / hyphens at the beginning
+    // of the card title
+    if (TrelloPro.settings['intend-cards']) {
+      // use title text without the card number attached to it
+      let cardTitle = $title.text().replace($projectNumber.text(), '');    
+      if (cardTitle.match(/^(\-{3}|\~{3})/g)) {
+        filterAttributes.push('tpro-intend-level3');
+        html = html.replace(/^(\-{3}|\~{3})/g, '');
+      } else if (cardTitle.match(/^(\-{2}|\~{2})/g)) {
+        filterAttributes.push('tpro-intend-level2');
+        html = html.replace(/^(\-{2}|\~{2})/g, '');
+      } else if (cardTitle.match(/^(\-{1}|\~{1})/g)) {
+        filterAttributes.push('tpro-intend-level1');        
+        html = html.replace(/^(\-{1}|\~{1})/g, '');        
+      }
+    }
+
     // wrap HTML
     $htmlWrapper = jQuery('<div></div>').html(html);
 
@@ -746,6 +764,7 @@ TrelloPro.load = function () {
     TrelloPro.toggleCssInject('hide-add-list');
     TrelloPro.toggleCssInject('beautify-markdown');
     TrelloPro.toggleCssInject('compact-cards');
+    TrelloPro.toggleCssInject('intend-cards');
 
 		TrelloPro.loaded = true;
 
@@ -754,7 +773,8 @@ TrelloPro.load = function () {
       || TrelloPro.settings['parse-labels']
       || TrelloPro.settings['parse-time-entries']
       || TrelloPro.settings['parse-priority-marks']
-      || TrelloPro.settings['parse-points'];
+      || TrelloPro.settings['parse-points']
+      || TrelloPro.settings['intend-cards'];
     if (parsing_on) {
       // run card name processing on all initial cards
       let $initCards = jQuery('.list-card-title');

--- a/options.html
+++ b/options.html
@@ -91,7 +91,12 @@
 						<input id="hide-activity-entries" name="hide-activity-entries" type="checkbox" />
 			  		<label for="hide-activity-entries">Hide "Activity" entries</label>
 					</div>
-
+					
+					<div class="tpro-setting">
+						<input id="intend-cards" name="intend-cards" type="checkbox" />
+			  		<label for="intend-cards">Intend cards by up to 3 levels</label>
+					</div>
+					
 				</div>
 				<div class="six columns">
 

--- a/tmpl/settings.html
+++ b/tmpl/settings.html
@@ -204,6 +204,18 @@
 						</div>
 					</div><!-- /.checklist-item -->
 
+					<!-- intend-cards -->
+					<div class="checklist-item">
+						<input type="checkbox" name="intend-cards" value="1">
+						<div class="checklist-item-checkbox enabled js-toggle-checklist-item">
+							<span class="icon-sm icon-check checklist-item-checkbox-check"></span>
+						</div>
+						<div class="checklist-item-details" attr="name">
+							<p class="checklist-item-details-text js-checkitem-name">Intend cards by up to 3 levels</p>
+							<p>By leading the card title either be <strong>-, -- or ---</strong> you can intend the cards up to <strong>three steps</strong>. In addition you can use ~ (tilde) instead of - (hyphen)</p>							
+						</div>
+					</div><!-- /.checklist-item -->
+
 				</div><!-- /.checklist-item-list -->
 				<br style="clear:both" />
 			</div>


### PR DESCRIPTION
A nice "visual" way we group some related cards in the same list together is by prepending the card title by one, two or three tildes characters (~). This pull request i did does intend the cards up to three levels when you prepend the card title by -, --, --- or ~, ~~, ~~~ visually (see screenshot). 

I use this method, for example, when some original card once had a checklist but then the points got separated to full cards. Then i prepend this cards with one or more tildes to not "lose" the checklist feeling/related feeling
![image](https://user-images.githubusercontent.com/22261975/27519387-47d9d9e2-59f3-11e7-8141-096d3a6c1fd9.png)

It would be nice if you can test it and merge it to the master or give me an advice to make it even better

(Edited to clean up my messy english)